### PR TITLE
Add some missing rewrite fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,6 @@
     "type": "git",
     "url": "https://github.com/darkobits/publish-root.git"
   },
-  "engines": {
-    "npm": "^5.0.0",
-    "node": "^6.0.0"
-  },
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -29,20 +29,20 @@
     "bump": "standard-version"
   },
   "dependencies": {
-    "@darkobits/log": "^1.0.0",
-    "configstore": "^3.1.1",
-    "convert-hrtime": "^2.0.0",
-    "fs-extra": "^5.0.0",
-    "glob": "^7.1.2"
+    "@darkobits/log": "^1.2.4",
+    "configstore": "^5.0.0",
+    "convert-hrtime": "^3.0.0",
+    "fs-extra": "^8.1.0",
+    "glob": "^7.1.6"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-preset-env": "1.x",
-    "eslint": "4.x",
-    "npm-run-all": "4.x",
-    "rimraf": "2.x",
-    "standard-version": "4.x",
-    "xo": "0.18.x"
+    "babel-preset-env": "^1.7.0",
+    "eslint": "^6.6.0",
+    "npm-run-all": "^4.1.5",
+    "rimraf": "^3.0.0",
+    "standard-version": "^7.0.0",
+    "xo": "^0.25.3"
   },
   "xo": {
     "env": [

--- a/src/bin/postpack.js
+++ b/src/bin/postpack.js
@@ -35,8 +35,8 @@ import log from '../lib/log';
     }
 
     log.verbose('restore', 'Restore complete.');
-  } catch (err) {
-    log.error('', err);
+  } catch (error) {
+    log.error('', error);
     process.exit(1);
   } finally {
     config.delete('startTime');

--- a/src/bin/prepack.js
+++ b/src/bin/prepack.js
@@ -73,8 +73,8 @@ import log from '../lib/log';
 
     // Write temporary manifest.
     await writeJson('package.json', pkgJson, {spaces: 2});
-  } catch (err) {
-    log.error('', err);
+  } catch (error) {
+    log.error('', error);
     process.exit(1);
   } finally {
     config.delete('startTime');

--- a/src/etc/constants.js
+++ b/src/etc/constants.js
@@ -42,11 +42,16 @@ export const EXCLUDE_FROM_BACKUP = [
  */
 export const REWRITE_FIELDS = [
   'bin',
-  'directories',
-  'main',
   'browser',
+  'directories',
+  'jsdelivr',
+  'main',
+  'man',
   'module',
-  'man'
+  'types',
+  'typings',
+  'umd:main',
+  'unpkg'
 ];
 
 


### PR DESCRIPTION
See:

  - https://github.com/stereobooster/package.json
  - https://www.jsdelivr.com/features#publishing-packages

Also removed the `engines` field as the specified node/npm versions are [obsolete](https://nodejs.org/en/about/releases/), prevent installation with yarn (without [manual intervention](https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-ignore-engines)), and aren't needed since this works with all maintained versions of node and npm, and doesn't have any dependencies on node/npm internals. 